### PR TITLE
add constant costs to KeyEconomicIndicators

### DIFF
--- a/src/aiecommon/Output/KeyEconomicIndicators.py
+++ b/src/aiecommon/Output/KeyEconomicIndicators.py
@@ -6,3 +6,4 @@ class KeyEconomicIndicators(BaseModel):
     payBackPeriod: Optional[float] = None
     totalInvestmentAfterSubsidy: int
     monthlySavingsAfterLoanPayment: int
+    constantCosts: int


### PR DESCRIPTION
This allows to return constant costs (independent from model decisions). I think this allows using this in the API but now, it's not ofc.